### PR TITLE
Bug fix: H0 incorrect when 1 scenario supplied

### DIFF
--- a/R/design_optimizer.R
+++ b/R/design_optimizer.R
@@ -688,8 +688,12 @@ design.performance.continuous.or.binary.outcome.type <-
       which(substring(colnames(outcome.mean), first=1, last=1)=="C")
     tx.cols <-
       which(substring(colnames(outcome.mean), first=1, last=1)!="C")
-    mean.differences <- outcome.mean[,tx.cols] -
-      kronecker(matrix(1, ncol=(n.arms-1)), outcome.mean[,control.cols])
+    
+    mean.differences <- 
+      matrix(outcome.mean[,tx.cols], nrow = nrow(outcome.mean)) -
+      kronecker(matrix(1, ncol=(n.arms-1)), 
+                matrix(outcome.mean[,control.cols],
+                       nrow = nrow(outcome.mean)))
       
 
     null.hypotheses <- 1*(mean.differences<1e-6) #Null hypotheses are of the form: mean_difference <= 0.


### PR DESCRIPTION
Bug caused by coercion of matrices to vectors when subset - This should work for 1+ scenarios supplied.